### PR TITLE
Small update the README for basic auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,9 @@ First, add the couchdb worker to your supervisor
     children = [
       {CouchDBEx.Worker, [
           hostname: "http://localhost",
-          basic_auth_username: "couchdb",
-          basic_auth_password: "couchdb"
+          username: "couchdb",
+          password: "couchdb",
+          auth_method: :basic
         ]}
     ]
 


### PR DESCRIPTION
Very glad to see another couchdb client for Elixir!

I tried following the steps in the README but it looks like the `basic_auth_username` and `basic_auth_password` parameters aren't supported anymore, figured I'd update the readme to reflect this.